### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 
 tera = { version = "1.15.0", default-features = false, optional = true }
-css-inline = { version = "0.8", optional = true }
+css-inline = { version = "0.10", optional = true }
 html2text = { version = "0.6.0", optional = true }


### PR DESCRIPTION
Hi! This PR updates `css-inline` to its latest version